### PR TITLE
rebuild vcpkg if does not run properly on 'vcpkg --version'

### DIFF
--- a/packages/run-vcpkg-lib/__tests__/run-vcpkg.bootstrap-on-version.test.ts
+++ b/packages/run-vcpkg-lib/__tests__/run-vcpkg.bootstrap-on-version.test.ts
@@ -12,6 +12,7 @@ import * as utils from '@lukka/base-util-lib';
 // Arrange.
 const isWin = process.platform === "win32";
 const gitRef = 'mygitref'
+const anotherGitRef = 'anothergitref'
 const gitPath = '/usr/local/bin/git';
 const vcpkgRoot = '/path/to/vcpkg';
 const vcpkgExeName = isWin ? "vcpkg.exe" : "vcpkg";
@@ -29,7 +30,7 @@ jest.spyOn(utils.BaseUtilLib.prototype, 'readFile').mockImplementation(
     if (testutils.areEqualVerbose(file, path.join(vcpkgRoot, '.artifactignore'))) {
       return [true, "!.git\n"];
     } else if (testutils.areEqualVerbose(file, path.join(vcpkgRoot, globals.vcpkgLastBuiltCommitId))) {
-      return [true, "anothergitref"];
+      return [true, anotherGitRef];
     }
     else
       throw `readFile called with unexpected file name: '${file}'.`;
@@ -76,7 +77,9 @@ testutils.testWithHeader('run-vcpkg must build (by running bootstrap) when the v
       [`${gitPath}`]:
         { code: 0, stdout: "git output" },
       [`${gitPath} rev-parse HEAD`]:
-        { code: 0, stdout: "differentgitref" },
+        { code: 0, stdout: anotherGitRef },
+      [`${path.join(vcpkgRoot, vcpkgExeName)} --version`]:
+        { 'code': 1, 'stdout': 'this is the "vcpkg --version" output with exit code=1' },
       [`${path.join(vcpkgRoot, vcpkgExeName)} install --recurse vcpkg_args --triplet triplet --clean-after-build`]:
         { 'code': 0, 'stdout': 'this is the vcpkg output' },
       [`${path.join(vcpkgRoot, vcpkgExeName)} remove --outdated --recurse`]:

--- a/packages/run-vcpkg-lib/__tests__/run-vcpkg.submodule.test.ts
+++ b/packages/run-vcpkg-lib/__tests__/run-vcpkg.submodule.test.ts
@@ -80,6 +80,8 @@ testutils.testWithHeader('run-vcpkg with vcpkg as submodule must build and insta
         { 'code': 0, 'stdout': 'this is git submodule output' },
       [`${gitPath} submodule status ${vcpkgRoot}`]:
         { 'code': 0, stdout: 'this is git submodule output' },
+      [`${path.join(vcpkgRoot, vcpkgExeName)} --version`]:
+        { 'code': 0, 'stdout': 'this is the "vcpkg --version" output with exit code=0' },
       [`${path.join(vcpkgRoot, vcpkgExeName)} install --recurse vcpkg_args --triplet triplet --clean-after-build`]:
         { 'code': 0, 'stdout': 'this is the vcpkg output' },
       [`${path.join(vcpkgRoot, vcpkgExeName)} remove --outdated --recurse`]:

--- a/packages/run-vcpkg-lib/src/vcpkg-runner.ts
+++ b/packages/run-vcpkg-lib/src/vcpkg-runner.ts
@@ -353,7 +353,7 @@ export class VcpkgRunner {
 
   private async checkExecutable(): Promise<boolean> {
     let needRebuild = false;
-    // If the executable file ./vcpkg/vcpkg is not present, force build. The fact that 'the repository is up to date' is meaningless.
+    // If the executable file ./vcpkg/vcpkg is not present or it is not wokring, force build. The fact that 'the repository is up to date' is meaningless.
     const vcpkgExePath: string = this.baseUtils.getVcpkgExePath(this.vcpkgDestPath);
     if (!this.baseUtils.fileExists(vcpkgExePath)) {
       this.tl.info("Building vcpkg is necessary as executable is missing.");
@@ -363,7 +363,13 @@ export class VcpkgRunner {
         await this.tl.execSync('chmod', ["+x", vcpkgExePath])
       }
       this.tl.info(`vcpkg executable exists at: '${vcpkgExePath}'.`);
+      const result = await this.tl.execSync(vcpkgExePath, ['--version']);
+      if (result.code != 0) { 
+        needRebuild = true;
+        this.tl.info(`vcpkg executable returned code ${result.code}, forcing a rebuild.`);
+      }
     }
+
     return needRebuild;
   }
 


### PR DESCRIPTION
when the vcpkg executable is available (e.g. restored from cache), but running "vcpkg --version" does not work for any reason (i.e. its exit code is not 0), let's rebuild vcpkg's executable by running bootstrap.
This helps for fixing: https://github.com/lukka/run-vcpkg/issues/69