### PR TITLE
warn user if vcpkg's executable cannot be found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ token.txt
 build
 coverage/*
 .DS_Store
+lerna-debug.log

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.6.2",
+  "version": "3.7.0",
   "command": {
     "bootstrap": {
       "hoist": true

--- a/packages/action-lib/package-lock.json
+++ b/packages/action-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukka/action-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukka/action-lib",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.0.0"

--- a/packages/action-lib/package.json
+++ b/packages/action-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukka/action-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Implementation of the continuous integration abstraction layer for GitHub Actions.",
   "repository": {
     "type": "git",
@@ -37,8 +37,8 @@
     "@actions/github": "^5.0.3",
     "@actions/glob": "^0.3.0",
     "@actions/io": "^1.1.2",
-    "@lukka/base-lib": "^3.6.2",
-    "@lukka/base-util-lib": "^3.6.2",
+    "@lukka/base-lib": "^3.7.0",
+    "@lukka/base-util-lib": "^3.7.0",
     "@types/adm-zip": "^0.4.32",
     "@types/follow-redirects": "^1.14.1",
     "@types/q": "^1.5.1",

--- a/packages/action-lib/src/action-lib.ts
+++ b/packages/action-lib/src/action-lib.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020-2021-2022 Luca Cappa
+// Copyright (c) 2019-2020-2021-2022-2023 Luca Cappa
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 

--- a/packages/assets-lib/package-lock.json
+++ b/packages/assets-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukka/assets-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukka/assets-lib",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "lerna": "^6.1.0",

--- a/packages/assets-lib/package.json
+++ b/packages/assets-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukka/assets-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Various assets.",
   "repository": {
     "type": "git",

--- a/packages/base-lib/package-lock.json
+++ b/packages/base-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukka/base-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukka/base-lib",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.0.0"

--- a/packages/base-lib/package.json
+++ b/packages/base-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukka/base-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Continuous integration systems abstraction layer.",
   "repository": {
     "type": "git",

--- a/packages/base-util-lib/package-lock.json
+++ b/packages/base-util-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukka/base-util-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukka/base-util-lib",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "lerna": "^6.1.0",

--- a/packages/base-util-lib/package.json
+++ b/packages/base-util-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lukka/base-util-lib",
-    "version": "3.6.2",
+    "version": "3.7.0",
     "description": "Utilities library for Continuous integration systems.",
     "repository": {
         "type": "git",
@@ -21,7 +21,7 @@
         "test": "jest"
     },
     "dependencies": {
-        "@lukka/base-lib": "^3.6.2",
+        "@lukka/base-lib": "^3.7.0",
         "fast-glob": "3.2.7"
     },
     "devDependencies": {

--- a/packages/base-util-lib/src/base-util-lib.ts
+++ b/packages/base-util-lib/src/base-util-lib.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2020-2021-2022 Luca Cappa
+// Copyright (c) 2019-2020-2021-2022-2023 Luca Cappa
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 
@@ -145,12 +145,12 @@ export class BaseUtilLib {
     return null;
   }
 
-  // Force 'name' env variable to have value of 'value'.
-  public setEnvVar(name: string, value: string): void {
-    // Set variable both as env var and as step variable, which might be re-used in subseqeunt steps.  
+    // Set both the environment variable and the workflow variable with the same name.
+    // The workflow variable might be re-used in subsequent steps.
+    public setEnvVar(name: string, value: string): void {
     process.env[name] = value;
     this.baseLib.setVariable(name, value);
-    this.baseLib.debug(`Set variable and the env variable '${name}' to value '${value}'.`);
+    this.baseLib.debug(`Set env ariable and the workflow variable named '${name}' to value '${value}'.`);
   }
 
   public trimString(value?: string): string {

--- a/packages/run-cmake-lib/__tests__/run-cmake.toolchain.test.ts
+++ b/packages/run-cmake-lib/__tests__/run-cmake.toolchain.test.ts
@@ -31,6 +31,7 @@ mock.inputsMocks.setInput(globals.cmakeListsTxtPath, cmakeListsTxtPath);
 
 testutils.testWithHeader('run-cmake with VCPKG_ROOT defined must configure and build and test successfully', async () => {
   process.env.VCPKG_ROOT = vcpkgRoot;
+  mock.VcpkgMocks.vcpkgExePath = vcpkgExePath;
   const answers: testutils.BaseLibAnswers = {
     "exec": {
       [`${gitPath}`]:

--- a/packages/run-cmake-lib/__tests__/utils_suite.test.ts
+++ b/packages/run-cmake-lib/__tests__/utils_suite.test.ts
@@ -10,80 +10,168 @@ import * as mock from '../../run-vcpkg-lib/__tests__/mocks'
 import * as testutils from '../../run-vcpkg-lib/__tests__/utils'
 import { BaseLib } from '@lukka/base-lib';
 
+function newUniqueName() {
+  return 'xxxxxxxxxxxxyxxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    var r = Math.random() * 16 | 0,
+      v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
+
+function getVcpkgEnvOutput(var1: string, var2: string) {
+  return `vcpkg env's output:\n${var1}=1\n${var2}=2\n`;
+}
+
 const baseLib: BaseLib = mock.exportedBaselib;
 const baseUtilLib: baseutillib.BaseUtilLib = new baseutillib.BaseUtilLib(baseLib);
-
 const vcpkgRoot = "/vcpkgroot/";
-const isWin = process.platform === "win32";
-const vcpkgExe = isWin ? 'vcpkg.exe' : 'vcpkg';
-const triplet = baseUtilLib.getDefaultTriplet();
-const vcpkgEnvOutput = "vcpkg env's output:\nA=1\nB=2\n";
-jest.spyOn(baseutillib.BaseUtilLib.prototype, 'isWin32').mockImplementation(() => isWin);
-const answers: testutils.BaseLibAnswers = {
-  "exec": {
-    [`${path.join(vcpkgRoot, vcpkgExe)} env --bin --include --tools --python --triplet ${triplet} set`]:
-      { code: 0, stdout: vcpkgEnvOutput },
-  },
-};
+const vcpkgExe = path.join(vcpkgRoot, 'vcpkg.exe')
+mock.VcpkgMocks.vcpkgExePath = vcpkgExe;
+const defaultTriplet = "default-triplet";
+// Run as it is Windows OS on any test run.
+jest.spyOn(baseutillib.BaseUtilLib.prototype, 'isWin32').mockImplementation(() => true);
 
 describe("cmakeutils tests", function () {
-  test("injectEnvVariables() should succeed", async () => {
+  test("setupMsvc() should succeed", async () => {
     // Arrange.
-    const answers2: testutils.BaseLibAnswers = {
-      "exec": {
-        [`${path.join(vcpkgRoot, vcpkgExe)} `]:
-          { code: 0, stdout: vcpkgEnvOutput },
-      },
-    };
-    mock.answersMocks.reset(answers2);
-
     const baseLib: BaseLib = mock.exportedBaselib;
     const baseUtilLib: baseutillib.BaseUtilLib = new baseutillib.BaseUtilLib(baseLib);
-
-    // Act
-    await cmakeutils.injectEnvVariables(baseUtilLib, vcpkgRoot, []);
-
-    // Assert
-    expect(process.env['A']).toBe('1');
-    expect(process.env['B']).toBe('2');
-
-    // Cleanup
-    delete process.env['A'];
-    delete process.env['B'];
-  });
-
-  test("injectEnvVariables() with args passed in.", async () => {
-    // Arrange
-    mock.answersMocks.reset(answers);
-
-    baseutillib.setEnvVarIfUndefined("VCPKG_DEFAULT_TRIPLET", baseUtilLib.getDefaultTriplet());
-    const vcpkgEnvArgsString: string = baseutillib.replaceFromEnvVar(cmakerunner.CMakeRunner.vcpkgEnvDefault);
-    const vcpkgEnvArgs: string[] = eval(vcpkgEnvArgsString);
-
-    // Act
-    await cmakeutils.injectEnvVariables(baseUtilLib, vcpkgRoot, vcpkgEnvArgs);
-
-    // Assert
-    expect(process.env['A']).toBe('1');
-    expect(process.env['B']).toBe('2');
-  });
-
-  test("injectEnvVariables() with 'vcpkg env' failure (exit code 1)", async () => {
-    // Arrange
-    mock.answersMocks.reset(answers);
-
-    const vcpkgEnvArgsString: string = baseutillib.replaceFromEnvVar(cmakerunner.CMakeRunner.vcpkgEnvDefault);
-    const vcpkgEnvArgs: string[] = eval(vcpkgEnvArgsString);
-
+    const msvcVariable1 = newUniqueName();
+    const msvcVariable2 = newUniqueName();
     const answers2: testutils.BaseLibAnswers = {
       "exec": {
-        [`${path.join(vcpkgRoot, vcpkgExe)} env --bin --include --tools --python --triplet ${triplet} set`]:
+        [`${vcpkgExe} `]:
+          { code: 0, stdout: getVcpkgEnvOutput(msvcVariable1, msvcVariable2) },
+      },
+    };
+    baseutillib.setEnvVarIfUndefined("VCPKG_DEFAULT_TRIPLET", defaultTriplet);
+    let envVarSetCount = 0;
+    mock.answersMocks.reset(answers2);
+    jest.spyOn(baseUtilLib, 'setEnvVar').mockImplementation((name, value) => {
+      switch (name) {
+        case msvcVariable1: expect(value).toStrictEqual('1'); envVarSetCount++; break;
+        case msvcVariable2: expect(value).toStrictEqual('2'); envVarSetCount++; break;
+        case 'CC': envVarSetCount++; break;
+        case 'CXX': envVarSetCount++; break;
+        default:
+          throw `unexpected name:'${name}' value:'${value}'`;
+      }
+    });
+
+    // Act
+    await cmakeutils.setupMsvc(baseUtilLib, vcpkgRoot, "[]");
+
+    // Assert
+    // CC, CXX and the two env var must be set. Its value are checked in the setEnvVar()'s mock.
+    expect(envVarSetCount).toEqual(4);
+  });
+
+  test("setupMsvc() should warn user about non existent vcpkg's exe", async () => {
+    // Arrange.
+    process.env.VCPKG_ROOT = "non-existent-path";
+    const answers2: testutils.BaseLibAnswers = {};
+    mock.answersMocks.reset(answers2);
+    const baseLib: BaseLib = mock.exportedBaselib;
+    const warningMock = jest.spyOn(baseLib, 'warning');
+    const baseUtilLib: baseutillib.BaseUtilLib = new baseutillib.BaseUtilLib(baseLib);
+    jest.spyOn(baseUtilLib, 'setEnvVar').mockImplementation((name, value) => {
+      switch (name) {
+        default:
+          throw `unexpected name '${name}' value '${value}'`;
+      }
+    });
+    // Tells there is not vcpkg.exe on disk.
+    mock.VcpkgMocks.vcpkgExeExists = false;;
+
+    // Act
+    await cmakeutils.setupMsvc(baseUtilLib, vcpkgRoot, "[]");
+
+    // Assert
+    expect(warningMock).toBeCalledTimes(1);
+
+    // Cleanup
+    warningMock.mockRestore();
+  });
+
+
+  test("setupMsvc() with args passed in.", async () => {
+    // Arrange
+    const msvcVariable1 = newUniqueName();
+    const msvcVariable2 = newUniqueName();
+    const answers: testutils.BaseLibAnswers = {
+      "exec": {
+        [`${vcpkgExe} env --bin --include --tools --python --triplet ${defaultTriplet} set`]:
+          { code: 0, stdout: getVcpkgEnvOutput(msvcVariable1, msvcVariable2) },
+      },
+    };
+    mock.answersMocks.reset(answers);
+    jest.spyOn(baseUtilLib, 'setEnvVar').mockImplementation((name, value) => {
+      switch (name) {
+        case msvcVariable1: expect(value).toStrictEqual('1'); envVarSetCount++; break;
+        case msvcVariable2: expect(value).toStrictEqual('2'); envVarSetCount++; break;
+        case 'CC': envVarSetCount++; break;
+        case 'CXX': envVarSetCount++; break;
+        default:
+          throw `unexpected name:'${name}' value:'${value}'`;
+      }
+    });
+    mock.VcpkgMocks.vcpkgExeExists = true;
+    let envVarSetCount = 0;
+    baseutillib.setEnvVarIfUndefined("VCPKG_DEFAULT_TRIPLET", defaultTriplet);
+
+    // Act
+    await cmakeutils.setupMsvc(baseUtilLib, vcpkgRoot,
+      cmakerunner.CMakeRunner.vcpkgEnvDefault);
+
+    // Assert
+    // CC, CXX and the two env var must be set. Its value are checked in the setEnvVar()'s mock.
+    expect(envVarSetCount).toEqual(4);
+  });
+
+  test("setupMsvc() with 'vcpkg env' failure (exit code 1)", async () => {
+    // Arrange
+    mock.VcpkgMocks.vcpkgExeExists = true;
+    const answers2: testutils.BaseLibAnswers = {
+      "exec": {
+        [`${vcpkgExe} env --bin --include --tools --python --triplet ${defaultTriplet} set`]:
           { code: 1, stdout: "" },
       },
     };
     mock.answersMocks.reset(answers2);
 
     // Act and Assert
-    await expect(() => cmakeutils.injectEnvVariables(baseUtilLib, vcpkgRoot, vcpkgEnvArgs)).rejects.toThrow();
+    await expect(async () => await cmakeutils.setupMsvc(baseUtilLib, vcpkgRoot,
+      cmakerunner.CMakeRunner.vcpkgEnvDefault)).rejects.toThrow();
+
   });
+
+  test("setupMsvc() must not set environment if non Windows host", async () => {
+    jest.spyOn(baseUtilLib, 'setEnvVar').mockImplementation((name, value) => {
+      switch (name) {
+        default:
+          throw `Must not set the environment (name:'${name}', value:'${value}')`;
+      }
+    });
+    mock.VcpkgMocks.vcpkgExeExists = true;
+    // Run as non Windows OS.
+    jest.spyOn(baseutillib.BaseUtilLib.prototype, 'isWin32').mockImplementation(() => false);
+    baseutillib.setEnvVarIfUndefined("VCPKG_DEFAULT_TRIPLET", defaultTriplet);
+    const injectMock = jest.spyOn(cmakeutils, 'injectEnvVariables');
+    const warningMock = jest.spyOn(baseLib, 'warning');
+
+    // Act
+    await cmakeutils.setupMsvc(baseUtilLib, vcpkgRoot,
+      cmakerunner.CMakeRunner.vcpkgEnvDefault);
+
+    // Assert
+    // Must not setup the environment
+    expect(injectMock).toBeCalledTimes(0);
+    // No warning messages, only info msg with: 'Skipping setting up the environment since the platform is not Windows'
+    expect(warningMock).toBeCalledTimes(0);
+    
+    // Cleanup
+    injectMock.mockRestore();
+    warningMock.mockRestore();
+  });
+
 });

--- a/packages/run-cmake-lib/package-lock.json
+++ b/packages/run-cmake-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukka/run-cmake-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukka/run-cmake-lib",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.0.0"

--- a/packages/run-cmake-lib/package.json
+++ b/packages/run-cmake-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lukka/run-cmake-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "CMake runner for continuous integration systems.",
   "repository": {
     "type": "git",
@@ -32,10 +32,10 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@lukka/action-lib": "^3.6.2",
-    "@lukka/base-lib": "^3.6.2",
-    "@lukka/base-util-lib": "^3.6.2",
-    "@lukka/run-vcpkg-lib": "^3.6.2",
+    "@lukka/action-lib": "^3.7.0",
+    "@lukka/base-lib": "^3.7.0",
+    "@lukka/base-util-lib": "^3.7.0",
+    "@lukka/run-vcpkg-lib": "^3.7.0",
     "@types/adm-zip": "^0.4.32",
     "@types/follow-redirects": "^1.14.1",
     "@types/q": "^1.5.1",

--- a/packages/run-cmake-lib/src/cmake-utils.ts
+++ b/packages/run-cmake-lib/src/cmake-utils.ts
@@ -1,49 +1,105 @@
-// Copyright (c) 2019-2020-2021-2022 Luca Cappa
+// Copyright (c) 2019-2020-2021-2022-2023 Luca Cappa
 // Released under the term specified in file LICENSE.txt
 // SPDX short identifier: MIT
 
-import * as cmakeutil from 'path';
 import * as baselib from '@lukka/base-lib';
 import * as baseutillib from '@lukka/base-util-lib';
+import * as cmakeutil from './cmake-utils'
+import * as path from 'path'
+import * as runvcpkglib from '@lukka/run-vcpkg-lib'
 
-export async function injectEnvVariables(baseUtils: baseutillib.BaseUtilLib, vcpkgRoot: string, args: string[]): Promise<void> {
+export function getVcpkgExePath(baseUtils: baseutillib.BaseUtilLib, vcpkgRoot: string): string {
   // Search for vcpkg tool and run it
-  let vcpkgPath: string = cmakeutil.join(vcpkgRoot, 'vcpkg');
+  let vcpkgPath: string = path.join(vcpkgRoot, 'vcpkg');
   if (baseUtils.isWin32()) {
     vcpkgPath += '.exe';
   }
-  const vcpkg: baselib.ToolRunner = baseUtils.baseLib.tool(vcpkgPath);
-  for (const arg of args) {
-    vcpkg.arg(arg);
-  }
+  return vcpkgPath;
+}
 
-  const options = {
-    cwd: vcpkgRoot,
-    failOnStdErr: false,
-    errStream: process.stdout,
-    outStream: process.stdout,
-    ignoreReturnCode: true,
-    silent: false,
-    windowsVerbatimArguments: false,
-    env: process.env
-  } as baselib.ExecOptions;
-
-  const output = await vcpkg.execSync(options);
-  if (output.code !== 0) {
-    throw new Error(`${output.stdout}\n\n${output.stderr}`);
-  }
-
-  const map = baseUtils.parseVcpkgEnvOutput(output.stdout);
-  for (const key in map) {
-    if (baseUtils.isVariableStrippingPath(key))
-      continue;
-    if (key.toUpperCase() === "PATH") {
-      process.env[key] = process.env[key] + cmakeutil.delimiter + map[key];
-    } else {
-      process.env[key] = map[key];
+export async function injectEnvVariables(baseUtils: baseutillib.BaseUtilLib, vcpkgRoot: string, args: string[]): Promise<void> {
+  try {
+    baseUtils.baseLib.debug(`injectEnvVariables()<<`);
+    const vcpkgPath = getVcpkgExePath(baseUtils, vcpkgRoot);
+    const vcpkg: baselib.ToolRunner = baseUtils.baseLib.tool(vcpkgPath);
+    for (const arg of args) {
+      vcpkg.arg(arg);
     }
-    baseUtils.baseLib.debug(`set ${key}=${process.env[key]}`)
+
+    const options = {
+      cwd: vcpkgRoot,
+      failOnStdErr: false,
+      errStream: process.stdout,
+      outStream: process.stdout,
+      ignoreReturnCode: true,
+      silent: false,
+      windowsVerbatimArguments: false,
+      env: process.env
+    } as baselib.ExecOptions;
+
+    const output = await vcpkg.execSync(options);
+    if (output.code !== 0) {
+      throw new Error(`vcpkg failed with: ${output.stdout}\n\n${output.stderr}`);
+    }
+
+    const map = baseUtils.parseVcpkgEnvOutput(output.stdout);
+    for (const key in map) {
+      let newValue: string | undefined;
+      if (baseUtils.isVariableStrippingPath(key))
+        continue;
+      if (key.toUpperCase() === "PATH") {
+        newValue = process.env[key] + path.delimiter + map[key];
+      } else {
+        newValue = map[key];
+      }
+      if (!newValue)
+        baseUtils.baseLib.warning(`The value for '${key}' cannot be determined.`);
+      else {
+        baseUtils.setEnvVar(key, newValue);
+        baseUtils.baseLib.debug(`set ${key}=${newValue}`);
+      }
+    }
+  }
+  finally {
+    baseUtils.baseLib.debug(`injectEnvVariables()>>`);
   }
 }
 
+export async function setupMsvc(
+  baseUtils: baseutillib.BaseUtilLib,
+  vcpkgRoot: string | undefined,
+  vcpkgEnvStringFormat: string): Promise<void> {
+  if (!baseUtils.isWin32()) {
+    baseUtils.baseLib.debug(`Skipping setting up the environment since the platform is not Windows.`);
+  } else {
+    await baseUtils.wrapOp(`Setup MSVC C/C++ toolset environment variables`, async () => {
+      if (!vcpkgRoot || vcpkgRoot.length == 0) {
+        baseUtils.baseLib.info(`Skipping setting up the environment since VCPKG_ROOT is not defined, and it is required to locate the vcpkg executable which provides the environment variables to be set for MSVC.`);
+        const vcpkgRoot: string | undefined = process.env[runvcpkglib.VCPKGROOT];
+      } else {
+        // if VCPKG_ROOT is defined, then use vcpkg to setup the environment.
+        if (process.env.CXX || process.env.CC) {
+          // If a C++ compiler is user-enforced, skip setting up the environment for MSVC.
+          baseUtils.baseLib.info(`Skipping setting up the environment since CXX or CC environment variables are defined. This allows user customization of used MSVC version.`);
+        } else {
+          const vcpkgPath = cmakeutil.getVcpkgExePath(baseUtils, vcpkgRoot);
+          if (!vcpkgPath || !baseUtils.fileExists(vcpkgPath)) {
+            baseUtils.baseLib.warning(`Skipping setting up the environment since vcpkg's executable is not found at: '${vcpkgPath}'.`);
+          } else {
+            // If defined(Win32) && (!defined(CC) && !defined(CXX)), let's hardcode CC and CXX so that CMake uses the MSVC toolset.
+            baseUtils.setEnvVar('CC', "cl.exe");
+            baseUtils.setEnvVar('CXX', "cl.exe");
 
+            // Use vcpkg to set the environment using provided command line (which includes the triplet).
+            // This is only useful to setup the environment for MSVC on Windows.
+            baseutillib.setEnvVarIfUndefined(runvcpkglib.VCPKGDEFAULTTRIPLET, baseUtils.getDefaultTriplet());
+            const vcpkgEnvArgsString: string = baseutillib.replaceFromEnvVar(vcpkgEnvStringFormat);
+            const vcpkgEnvArgs: string[] = eval(vcpkgEnvArgsString);
+            baseUtils.baseLib.debug(`'vcpkg env' arguments: ${vcpkgEnvArgs}`);
+            await cmakeutil.injectEnvVariables(baseUtils, vcpkgRoot, vcpkgEnvArgs);
+          }
+        }
+      }
+    });
+  }
+}

--- a/packages/run-vcpkg-lib/__tests__/mocks.ts
+++ b/packages/run-vcpkg-lib/__tests__/mocks.ts
@@ -56,6 +56,15 @@ jest.spyOn(baseutillib.BaseUtilLib.prototype, 'setVariableIfUndefined').mockImpl
     console.log(`call to mocked baseUtilLib.setVariableIfUndefined(${name}, ${value})`);
   }
 );
+jest.spyOn(baseutillib.BaseUtilLib.prototype, 'wrapOp').mockImplementation(
+  (name: string, fn: () => Promise<unknown>): Promise<unknown> => {
+    return fn();
+  });
+jest.spyOn(baseutillib.BaseUtilLib.prototype, 'wrapOpSync').mockImplementation(
+  (name: string, fn: () => unknown): unknown => {
+    return fn();
+  })
+
 
 // Mock for environment variables.
 export const envVarSetDict: { [name: string]: string } = {};

--- a/packages/run-vcpkg-lib/__tests__/utils.ts
+++ b/packages/run-vcpkg-lib/__tests__/utils.ts
@@ -68,7 +68,7 @@ export class MockAnswers {
             return answer;
         }
 
-        debug(`no mock found registered for cmd=${JSON.stringify(cmd)} key=${key}, mocks=${JSON.stringify(this)}`);
+        debug(`no mock found registered for cmd=${JSON.stringify(cmd)} key='${key}', mocks=${JSON.stringify(this)}`);
         throw new Error("No response found");
     }
 

--- a/packages/run-vcpkg-lib/package-lock.json
+++ b/packages/run-vcpkg-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lukka/run-vcpkg-lib",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@lukka/run-vcpkg-lib",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "lerna": "^6.1.0"

--- a/packages/run-vcpkg-lib/package.json
+++ b/packages/run-vcpkg-lib/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lukka/run-vcpkg-lib",
-	"version": "3.6.2",
+	"version": "3.7.0",
 	"description": "vcpkg runner for continuous integration systems.",
 	"repository": {
 		"type": "git",
@@ -21,9 +21,9 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"@lukka/action-lib": "^3.6.2",
-		"@lukka/base-lib": "^3.6.2",
-		"@lukka/base-util-lib": "^3.6.2",
+		"@lukka/action-lib": "^3.7.0",
+		"@lukka/base-lib": "^3.7.0",
+		"@lukka/base-util-lib": "^3.7.0",
 		"@types/adm-zip": "^0.4.32",
 		"@types/follow-redirects": "^1.14.1",
 		"@types/q": "^1.5.1",


### PR DESCRIPTION
when setting up the environment for building with MSVC on Windows, run-cmake uses vcpkg to set up the environment variables. if vcpkg.exe is missing for any reason, warn the user about it.